### PR TITLE
Fix order of parameters for Math.atan2

### DIFF
--- a/src/eval/op.ts
+++ b/src/eval/op.ts
@@ -23,7 +23,7 @@ export const knownBinaryOpMap: KnownBinaryOpMap = {
 	greaterThan: (a, b) => (a > b ? 1 : 0),
 	greaterThanEq: (a, b) => (a >= b ? 1 : 0),
 	strictEqual: (a, b) => (a === b ? 1 : 0),
-	angle: (x, y) => Math.atan2(x, y),
+	angle: (x, y) => Math.atan2(y, x),
 	len: (x, y) => Math.sqrt(x ** 2 + y ** 2),
 	shl: (a, b) => a << b,
 	shr: (a, b) => a >> b,


### PR DESCRIPTION
For some reason the `Math.atan2` method takes the `y` parameter before the `x` parameter, so this pr fixes the method call.